### PR TITLE
Allow output csv when fetching fics to be in a different directory and handle error files appropriately

### DIFF
--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -289,7 +289,7 @@ def main():
 	os.chdir(os.getcwd())
 	with open(csv_out, 'a') as f_out:
 		writer = csv.writer(f_out)
-		with open("errors_" + csv_out, 'a') as e_out:
+		with open(os.path.join(os.path.dirname(csv_out), "errors_" + os.path.basename(csv_out)), 'a') as e_out:
 			errorwriter = csv.writer(e_out)
 			#does the csv already exist? if not, let's write a header row.
 			if os.stat(csv_out).st_size == 0:


### PR DESCRIPTION
As stated, allows the output csv to be in a different directory (e.g. `outputs/`) and handle the error file creation there appropriately.