### PR TITLE
ao3_work_ids improvements -- load existing seen_ids, retry on 429

### DIFF
--- a/ao3_work_ids.py
+++ b/ao3_work_ids.py
@@ -28,7 +28,7 @@ tags = []
 # keep track of all processed ids to avoid repeats:
 # this is separate from the temporary batch of ids
 # that are written to the csv and then forgotten
-seen_ids = []
+seen_ids = set()
 
 # 
 # Ask the user for:
@@ -103,6 +103,7 @@ def get_args():
 # 
 def get_ids(header_info=''):
     global page_empty
+    global seen_ids
     headers = {'user-agent' : header_info}
     req = requests.get(url, headers=headers)
     soup = BeautifulSoup(req.text, "lxml")
@@ -126,13 +127,13 @@ def get_ids(header_info=''):
                 t = t[5:]
                 if not t in seen_ids:
                     ids.append(t)
-                    seen_ids.append(t)
+                    seen_ids.add(t)
         else:
             t = tag.get('id')
             t = t[5:]
             if not t in seen_ids:
                 ids.append(t)
-                seen_ids.append(t)
+                seen_ids.add(t)
     return ids
 
 # 
@@ -240,9 +241,19 @@ def process_for_ids(header_info=''):
         write_ids_to_csv(ids)
         update_url_to_next_page()
 
+def load_existing_ids():
+    global seen_ids
+    with open(csv_name + ".csv", 'r') as csvfile:
+        id_reader = csv.reader(csvfile)
+        for row in id_reader:
+            seen_ids.add(row[0])
+
 def main():
     header_info = get_args()
     make_readme()
+
+    print ("loading existing file ...\n")
+    load_existing_ids()
 
     print ("processing...\n")
 

--- a/ao3_work_ids.py
+++ b/ao3_work_ids.py
@@ -104,8 +104,14 @@ def get_args():
 def get_ids(header_info=''):
     global page_empty
     global seen_ids
+
+    # make the request. if we 429, try again later 
     headers = {'user-agent' : header_info}
     req = requests.get(url, headers=headers)
+    while req.status_code == 429:
+        # 5 second delay between requests as per AO3's terms of service
+        time.sleep(5)
+        req = requests.get(url, headers=headers)
     soup = BeautifulSoup(req.text, "lxml")
 
     # some responsiveness in the "UI"


### PR DESCRIPTION
Problem: the script quit on me after ~100-150 pages of pulling IDs.

Fixes:
1. Load existing `seen_ids` from the CSV output file provided. Means we will add to the existing file *and* avoid duplicate IDs.
2. Make `seen_ids` a `set`. Minor improvement, but it's mostly look up, so a set is better.
3. Retries on 429. A `429 Retry Later` causes the script to think there are no more works and subsequently quit out. This retries with a 5s delay until we get a non-429 response. 