### PR TITLE
Have --restart pick up IDs from the output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Now, to actually get the fics, run `python ao3_get_fanfics.py sherlock.csv`. You
 
 If you don't want to give it a .csv file name, you can also query a single fic id, `python ao3_get_fanfics.py 5937274`, or enter an arbitrarily sized list of them, `python ao3_get_fanfics.py 5937274 7170752`.
 
-If you stop a scrape from a csv partway through (or it crashes), you can restart the script using the flag `--restart`.  The scraper will skip all ids in the output file and the error file.
+If you stop a scrape from a csv partway through (or it crashes), you can resume the script using the flag `--resume`.  The scraper will skip all ids in the output file and the error file. (This previously was handled by `--restart ID`.)
 
 We cannot scrape fics that are locked (for registered users only), but submit a pull request if you want to build authentication!
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Now, to actually get the fics, run `python ao3_get_fanfics.py sherlock.csv`. You
 
 If you don't want to give it a .csv file name, you can also query a single fic id, `python ao3_get_fanfics.py 5937274`, or enter an arbitrarily sized list of them, `python ao3_get_fanfics.py 5937274 7170752`.
 
-If you stop a scrape from a csv partway through (or it crashes), you can restart from the last uncollected work_id using the flag `--restart 012345` (the work_id).  The scraper will skip all ids up to that point in the csv, then begin again from the given id. 
+If you stop a scrape from a csv partway through (or it crashes), you can restart the script using the flag `--restart`.  The scraper will skip all ids in the output file and the error file.
 
-We cannot scrape fics that are locked (for registered users only), but submit a pull request if you want to build authentication! 
+We cannot scrape fics that are locked (for registered users only), but submit a pull request if you want to build authentication!
 
 **Note that the 5 second delays before requesting from AO3's server are in compliance with the AO3 terms of service.  Please do not remove these delays.**
 
-Happy scraping! 
+Happy scraping!
 
 ## Improvements
 
@@ -62,7 +62,7 @@ We love pull requests!
 
 ## FF.net
 
-Want to scrape fanfiction.net? Check out my friend [@smilli](https://github.com/smilli/)'s [ff.net scraper](https://github.com/smilli/fanfiction)! 
+Want to scrape fanfiction.net? Check out my friend [@smilli](https://github.com/smilli/)'s [ff.net scraper](https://github.com/smilli/fanfiction)!
 
 ## License
 This work is licensed under the Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0). Feel free to use it and adapt it however you want, but don't make money off of it!

--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -20,7 +20,7 @@
 # csv output file. If left blank, it will be called "fanfics.csv"
 # Note that by default, the script appends to existing csvs instead of overwriting them.
 # 
-# --restart is an optional flag which will skip over IDs in the csv output and error files
+# --resume is an optional flag which will skip over IDs in the csv output and error files
 # when used in combination with a csv input
 #
 # --bookmarks is an optional flag which collects the users who have bookmarked a fic.
@@ -270,8 +270,8 @@ def get_args():
 		'--header', default='',
 		help='user http header')
 	parser.add_argument(
-		'--restart', action='store_true',
-		help='restart script and skip over already processed fics')
+		'--resume', action='store_true',
+		help='resume script and skip over already processed fics')
 	parser.add_argument(
 		'--firstchap', default='', 
 		help='only retrieve first chapter of multichapter fics')
@@ -288,7 +288,7 @@ def get_args():
 	fic_ids = args.ids
 	csv_out = str(args.csv)
 	headers = str(args.header)
-	restart = args.restart
+	resume = args.resume
 	ofc = str(args.firstchap)
 	lang = str(args.lang)
 	include_bookmarks = args.bookmarks
@@ -299,18 +299,18 @@ def get_args():
 		ofc = False
 	if lang == "":
 		lang = False
-	return fic_ids, csv_out, headers, restart, ofc, lang, include_bookmarks, metadata_only
+	return fic_ids, csv_out, headers, resume, ofc, lang, include_bookmarks, metadata_only
 
 '''
 
 '''
-def generate_fic_ids(fic_ids, restart, csv_out, errors_out):
+def generate_fic_ids(fic_ids, resume, csv_out, errors_out):
 	# check csv_out and errors_out for any processed IDs.
 	# technically this will also add the header row, but it's not like that will match any actual fic ID.
 	# CAUTION: a little wonky because we're using these files as input after we've already opened them
 	# for output. But we're reading the whole file (and closing it) before we generate any IDs to fetch.
 	seen_ids = set()
-	if restart:
+	if resume:
 		for filename in (csv_out, errors_out):
 			if os.path.exists(filename):
 				print("skipping fic IDs in", filename)
@@ -336,7 +336,7 @@ def generate_fic_ids(fic_ids, restart, csv_out, errors_out):
 			yield fic_id
 
 def main():
-	fic_ids, csv_out, headers, restart, only_first_chap, lang, include_bookmarks, metadata_only = get_args()
+	fic_ids, csv_out, headers, resume, only_first_chap, lang, include_bookmarks, metadata_only = get_args()
 	os.chdir(os.getcwd())
 	# if the output pathname includes a folder, make sure it exists.  if not, create it.
 	output_directory = os.path.dirname(csv_out)
@@ -357,7 +357,7 @@ def main():
 				writer.writerow(header)
 				writer.flush()
 
-			for fic_id in generate_fic_ids(fic_ids, restart, csv_out, errors_out):
+			for fic_id in generate_fic_ids(fic_ids, resume, csv_out, errors_out):
 				write_fic_to_csv(fic_id, only_first_chap, lang, include_bookmarks, metadata_only, writer, errorwriter, headers)
 				time.sleep(delay)
 

--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -355,7 +355,7 @@ def main():
 				print('Writing a header row for the csv.')
 				header = ['work_id', 'title', 'author', 'rating', 'category', 'fandom', 'relationship', 'character', 'additional tags', 'language', 'published', 'status', 'status date', 'words', 'chapters', 'comments', 'kudos', 'bookmarks', 'hits', 'all_kudos', 'all_bookmarks', 'body']
 				writer.writerow(header)
-				writer.flush()
+				f_out.flush()
 
 			for fic_id in generate_fic_ids(fic_ids, resume, csv_out, errors_out):
 				write_fic_to_csv(fic_id, only_first_chap, lang, include_bookmarks, metadata_only, writer, errorwriter, headers)

--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -324,15 +324,11 @@ def generate_fic_ids(fic_ids, restart, csv_out, errors_out):
 		csv_fname = fic_ids[0]
 		with open(csv_fname, 'r+') as f_in:
 			reader = csv.reader(f_in)
-			found_restart = not restart
 			for row in reader:
 				if not row:
 					continue
-				found_restart = found_restart or (row[0] not in seen_ids)
-				if found_restart:
+				if row[0] not in seen_ids:
 					yield row[0]
-				else:
-					print('Skipping already processed fic')
 	else:
 		# this is a little bit strange, but since yielding from the CSV is cleaner,
 		# this also needs to yield rather than returning the list.

--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -311,14 +311,13 @@ def generate_fic_ids(fic_ids, restart, csv_out, errors_out):
 	# for output. But we're reading the whole file (and closing it) before we generate any IDs to fetch.
 	seen_ids = set()
 	if restart:
-		with open(csv_out, 'r') as csvfile:
-			id_reader = csv.reader(csvfile)
-			for row in id_reader:
-				seen_ids.add(row[0])
-		with open(errors_out, 'r') as csvfile:
-			id_reader = csv.reader(csvfile)
-			for row in id_reader:
-				seen_ids.add(row[0])
+		for filename in (csv_out, errors_out):
+			if os.path.exists(filename):
+				print("skipping fic IDs in", filename)
+				with open(filename, 'r') as csvfile:
+					id_reader = csv.reader(csvfile)
+					for row in id_reader:
+						seen_ids.add(row[0])
 
 	# check if we got a CSV file. If so, open it and yield each ID.
 	if (len(fic_ids) == 1 and '.csv' in fic_ids[0]):

--- a/ao3_get_fanfics.py
+++ b/ao3_get_fanfics.py
@@ -20,8 +20,8 @@
 # csv output file. If left blank, it will be called "fanfics.csv"
 # Note that by default, the script appends to existing csvs instead of overwriting them.
 # 
-# --restart is an optional string which when used in combination with a csv input will start
-# the scraping from the given work_id, skipping all previous rows in the csv
+# --restart is an optional flag which will skip over IDs in the csv output and error files
+# when used in combination with a csv input
 #
 # --bookmarks is an optional flag which collects the users who have bookmarked a fic.
 # Because this is a slow operation, it is excluded by default.
@@ -270,8 +270,8 @@ def get_args():
 		'--header', default='',
 		help='user http header')
 	parser.add_argument(
-		'--restart', default='', 
-		help='work_id to start at from within a csv')
+		'--restart', action='store_true',
+		help='restart script and skip over already processed fics')
 	parser.add_argument(
 		'--firstchap', default='', 
 		help='only retrieve first chapter of multichapter fics')
@@ -288,7 +288,7 @@ def get_args():
 	fic_ids = args.ids
 	csv_out = str(args.csv)
 	headers = str(args.header)
-	restart = str(args.restart)
+	restart = args.restart
 	ofc = str(args.firstchap)
 	lang = str(args.lang)
 	include_bookmarks = args.bookmarks
@@ -304,35 +304,28 @@ def get_args():
 '''
 
 '''
-def process_id(fic_id, restart, found):
-	if found:
-		return True
-	if fic_id == restart:
-		return True
-	else:
-		return False
-
-def generate_fic_ids(fic_ids, csv_out, errors_out):
+def generate_fic_ids(fic_ids, restart, csv_out, errors_out):
 	# check csv_out and errors_out for any processed IDs.
 	# technically this will also add the header row, but it's not like that will match any actual fic ID.
 	# CAUTION: a little wonky because we're using these files as input after we've already opened them
 	# for output. But we're reading the whole file (and closing it) before we generate any IDs to fetch.
 	seen_ids = set()
-	with open(csv_out, 'r') as csvfile:
-		id_reader = csv.reader(csvfile)
-		for row in id_reader:
-			seen_ids.add(row[0])
-	with open(errors_out, 'r') as csvfile:
-		id_reader = csv.reader(csvfile)
-		for row in id_reader:
-			seen_ids.add(row[0])
+	if restart:
+		with open(csv_out, 'r') as csvfile:
+			id_reader = csv.reader(csvfile)
+			for row in id_reader:
+				seen_ids.add(row[0])
+		with open(errors_out, 'r') as csvfile:
+			id_reader = csv.reader(csvfile)
+			for row in id_reader:
+				seen_ids.add(row[0])
 
 	# check if we got a CSV file. If so, open it and yield each ID.
 	if (len(fic_ids) == 1 and '.csv' in fic_ids[0]):
 		csv_fname = fic_ids[0]
 		with open(csv_fname, 'r+') as f_in:
 			reader = csv.reader(f_in)
-			found_restart = False
+			found_restart = not restart
 			for row in reader:
 				if not row:
 					continue
@@ -362,7 +355,6 @@ def main():
 		writer = csv.writer(f_out)
 		with open(errors_out, 'a', newline="") as e_out:
 			errorwriter = csv.writer(e_out)
-
 			#does the csv already exist? if not, let's write a header row.
 			if os.stat(csv_out).st_size == 0:
 				print('Writing a header row for the csv.')
@@ -370,7 +362,7 @@ def main():
 				writer.writerow(header)
 				writer.flush()
 
-			for fic_id in generate_fic_ids(fic_ids, csv_out, errors_out):
+			for fic_id in generate_fic_ids(fic_ids, restart, csv_out, errors_out):
 				write_fic_to_csv(fic_id, only_first_chap, lang, include_bookmarks, metadata_only, writer, errorwriter, headers)
 				time.sleep(delay)
 


### PR DESCRIPTION
# PROBLEM STATEMENT

Sometimes my internet cuts out and then my script quits. It's annoying to go dig out the next fic id, verify it, and slap it as a parameter into `--restart`. I just want to `--resume`

# SOLUTION

These commits will skip fic ids that are in the output files (the csv fic file and the error file) IF

1. you pass the `--resume` flag, no parameter
2. you pass in an input for the fic ids. (I'm not sure why this was differentiated between if you pass fic IDs directly vs pass in a CSV, but sure, we can keep that.)

PLEASE NOTE: THIS PR REMOVES `--restart ID`. I had originally just used the same flag and gave it new functionality, but I decided to give it a new name.

# CAVEATS

A tad controversial in that

1. You can't decide you want to use different output file names when continuing your run. I have no idea how big your files get, but this basically means you can't decide to "manually batch" by quitting out and starting at some other fic id. (I'm downloading only metadata for 90k fic and decided that I'm cool with 90 MB file. I don't know how big if you're downloading Actual Fic.)
2. if you want to retry your errored fics by passing in the error fic id list (without renaming it) as the input ... the script will do nothing on `--resume`. It will behave reasonably if you don't `--resume`. But also this is just straight up wonky anyways because you're using the same file as input and error output which is ... yeah, don't do that.
5. [extra, extra pedantic as if the above wasn't already] if you want to re-download already processed fic (into the same file) starting from some point in the fic id list ... you can't. I don't know why you want to do this because you'd end up with two of the same fic in the same file, but I guess you also get an updated version.

# NOTES

First, I recommend looking at the first commit by itself. I just really wanted the write path to be the same for whether you pass in a CSV list of ids or pass them all from the command line.

My best guess for this flag is that it's meant to kick the script when something has gone wrong in the middle and you Just Want More Fic From The List. If so, this is easier! Albeit a little more magic and therefore slightly less predictable.

If you can live with that, then this allows you to just run `--resume` without finding what the next fic id is! Hooray!

Hm, I could have it error out if you try to pass the error file as the input list.

Well, let me know if there are any bits I ought to revisit.

By the way, thanks for that fix in `ao3_work_ids` in case there is no file! Can't give you kudos for it, so, here I am. Added that check here, too.